### PR TITLE
Disable HTTPS certificate verification

### DIFF
--- a/lib/ESPGameAPI/include/AsyncRequest.hpp
+++ b/lib/ESPGameAPI/include/AsyncRequest.hpp
@@ -8,43 +8,11 @@
 
 extern "C" {
   #include "esp_http_client.h"
-  #include "esp_crt_bundle.h"
   #include "freertos/FreeRTOS.h"
   #include "freertos/task.h"
   #include "freertos/semphr.h"
   #include "esp_log.h"
 }
-
-// Minimal root certificate (Let's Encrypt ISRG Root X1). Public trust anchor.
-// If your production server uses a different CA, replace this with the correct
-// root or intermediate (full PEM including BEGIN/END lines).
-static const char ESPGAMEAPI_LE_ROOT_CA[] =
-  "-----BEGIN CERTIFICATE-----\n"
-  "MIIFazCCA1OgAwIBAgISA2Gv2XDSBxPT7khb0g2g3PpeMA0GCSqGSIb3DQEBCwUA\n"
-  "MEoxCzAJBgNVBAYTAlVTMRkwFwYDVQQKExBHbG9iYWxTaWduIG52LXNhMR8wHQYD\n"
-  "VQQDExZHbG9iYWxTaWduIFJvb3QgQ0EgLSBHMzAeFw0yMTA2MDkwMDAwMDBaFw0z\n"
-  "MTA2MDgyMzU5NTlaMEoxCzAJBgNVBAYTAlVTMRkwFwYDVQQKExBHbG9iYWxTaWdu\n"
-  "IG52LXNhMR8wHQYDVQQDExZHbG9iYWxTaWduIFJvb3QgQ0EgLSBHMzCCAiIwDQYJ\n"
-  "KoZIhvcNAQEBBQADggIPADCCAgoCggIBAL4E3+3HJEVG2jzX+sK1yqEbckZypPtu\n"
-  "x3N3aR6Vrn956xWxBY2NU4VFIfE88ll/aT0wZqbt1zsa3RqeM8glvc/9d7H5PHeT\n"
-  "79Gql8BKq+2H9yY13NUy9TgrIOPNVbZ4SfibYwypy0YQm5m7/7cJ8e91bUb9Nr2y\n"
-  "7oaoGz5o1io8GZFOD4oTi27C/7fyqCkCmZJLdnOjFkMrDXLI4YAlnXrhIRbkIuAe\n"
-  "GHWxirDLJzi10BGSAdoo6gWQBaIj++ImQxGc1dQc5sKXc5teLoI0lpBT1sIwoMvV\n"
-  "YI2bQVh0b07XHtcwPa5RWPLXnwI75PwQxzb62LF8oT+yQUwpsOSJyYwcmBHQYaNx\n"
-  "1Pr4QMzNp+Oz2n1Uc3C3xaQa58aeGeq/QAdzTZziEtGlUZEM6IuEI4P1N2fN1j4P\n"
-  "iuF4r1xYDs8SuFD/yYlLeI2c2MvmFo0xSg6uSPRqCM/jHdCqkfNNpJBbGAbIYW/W\n"
-  "04O6J2JkFh2RFxYDs2fzGEGZm4G6dkprdFMIALlTyBC0bYKT1eZq9VHtV6nRvWmv\n"
-  "AaylJ14rx+Q7aC6fI0bI1XHlzTH0jzZMfjNV8iPBUFeCFGXFZ8bJHPsuacF6nwLx\n"
-  "wY0jzQDnE466+vWXT14BMWrMUR3pvN8MPv+2MvmP0xSg6hZKkd06Pq4jG3Ejj6in\n"
-  "UoxBqMcCAwEAAaNCMEAwDwYDVR0TAQH/BAUwAwEB/zAOBgNVHQ8BAf8EBAMCAQYw\n"
-  "HQYDVR0OBBYEFKVar/6AFH2LxwC0ZFwEukgqS0bYMA0GCSqGSIb3DQEBCwUAA4IBAQBR\n"
-  "bUY8ailqXF/w3vGN9VOGBev5nYeD1yfknhk+aoCA8DmF5asJ5AZt0pOEtpJR/YWZ\n"
-  "GT+b/xGaxzwoMPmxjSPdZRhqUTrWyd4InENcy+XUG6uHgnIY7qDpiRnwV0wweAV2\n"
-  "OZXS6jttuPAHyBs+K6TfGsDzpDHK5vVsQt1zAr72Xd1LSeX776BF3/f6/Dr7guP5\n"
-  "tSUUQeFk/gQq/i323iDL49myIIZeF1P0uohsEiL/KZ8nfdXbra+XUl3Bd6mV9Ezg\n"
-  "zszbmWzxubUoil58x2oyS9MhUlCT3VkOITkkpFmS6r30YIOCwRvDDDeZPAHDqGRID\n"
-  "pHu6HgMHqmpYJv1nVbWcv1O3\n"
-  "-----END CERTIFICATE-----\n";
 
 class AsyncRequest {
 public:
@@ -175,8 +143,11 @@ private:
     cfg.timeout_ms = 7000;
 
   // --- TLS configuration --------------------------------------------------
-  cfg.cert_pem = ESPGAMEAPI_LE_ROOT_CA;       // minimal trust anchor
-  cfg.skip_cert_common_name_check = true;     // hostname relaxed per user request
+  // No CA certificate is supplied which disables server verification.
+  // This allows HTTPS connections without validating the peer's identity.
+  cfg.cert_pem = nullptr;                     // insecure: accept any cert
+  cfg.use_global_ca_store = false;            // do not use built-in store
+  cfg.skip_cert_common_name_check = true;     // also skip hostname check
 
     ctx->client = esp_http_client_init(&cfg);
     if (!ctx->client) { 


### PR DESCRIPTION
## Summary
- remove static root certificate bundle and esp_crt_bundle include
- configure AsyncRequest to skip TLS certificate verification and hostname checks

## Testing
- `pio run` *(fails: HTTPClientError)*

------
https://chatgpt.com/codex/tasks/task_e_68b75fbbe3fc832da5a8c7a66cc75e67